### PR TITLE
fix: #110 '*' char in WIT doc comments

### DIFF
--- a/wit/server/handler.wit
+++ b/wit/server/handler.wit
@@ -1,7 +1,7 @@
 /// MCP server-side handler interface and composition worlds.
 ///
 /// <https://modelcontextprotocol.io>
-package wasmcp:server@0.1.0;
+package wasmcp:server@0.1.1;
 
 /// Server-side MCP message handler.
 @since(version = 0.1.0)

--- a/wit/server/notifications.wit
+++ b/wit/server/notifications.wit
@@ -4,11 +4,11 @@
 /// to clients over output streams. Notifications are one-way messages that don't expect responses.
 ///
 /// Categories:
-/// - **Progress**: Real-time updates on long-running operations
-/// - **Logging**: Send log messages to client's logging system
-/// - **List changes**: Notify when tools/prompts/resources are added/removed
-/// - **Subscriptions**: Push updates to subscribed resources/prompts
-/// - **Elicitation**: Request information from the client (roots, sampling)
+/// - Progress: Real-time updates on long-running operations
+/// - Logging: Send log messages to client's logging system
+/// - List changes: Notify when tools/prompts/resources are added/removed
+/// - Subscriptions: Push updates to subscribed resources/prompts
+/// - Elicitation: Request information from the client (roots, sampling)
 ///
 /// <https://spec.modelcontextprotocol.io/specification/basic/notifications>
 @since(version = 0.1.0)
@@ -92,7 +92,7 @@ interface notifications {
         logger: option<string>,
     ) -> result<_, notification-error>;
 
-    /// Send a `notifications/*/list_changed` notification to the client
+    /// Send a `list_changed` notification to the client
     ///
     /// When the server's list of tools, prompts, or resources changes (additions,
     /// removals, or modifications), this notification informs the client to re-fetch
@@ -111,7 +111,7 @@ interface notifications {
         changes: server-lists,
     ) -> result<_, notification-error>;
 
-    /// Send a `notifications/*/updated` notification to the client
+    /// Send a `updated` notification to the client
     ///
     /// For resources and prompts that support subscriptions, this notification
     /// pushes updates to clients that have subscribed. The update includes the


### PR DESCRIPTION
Issue: https://github.com/wasmcp/wasmcp/issues/110

A '*' char in the doc comments of `interface notifications` in wit/server/notifications.wit causes `jco guest-types` to fail with

```bash
src/generated/interfaces/wasmcp-server-notifications.d.ts:41:42 - error TS1443: Module declaration names may only use ' or " quoted strings.

 41    * Send a `notifications/*/list_changed` notification to the client
                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 42    *
    ~~~~
...
 54   /**
    ~~~~~
 55    * Send a `notifications/*/updated` notification to the client
    ~~~~~~~~~~~~~

Found 1 error in src/generated/interfaces/wasmcp-server-notifications.d.ts:41

make: *** [build] Error 2
```